### PR TITLE
A few more fixes for multi network VMs + oidc auth option

### DIFF
--- a/Vagrant.md
+++ b/Vagrant.md
@@ -37,6 +37,15 @@ $ vagrant up
 
 - Edit the [inventory](inventory/vagrant/inventory.yml) file and check if the information is correct
 
+- Add vagrant's default ssh-key to your ssh-agent
+```ShellSession
+ssh-add ~/.vagrant/insecure_private_key
+```
+if not using a ssh-agent, add this to ansible.cfg
+```ShellSession
+private_key_file = ~/.vagrant.d/insecure_private_key
+```
+
 - Test the ssh connection to all instances in your `inventory.yml`:
 
 ```ShellSession

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-# Use this to overwrite the role defaults
+### Use this to overwrite the role defaults
 # k0s_version: v1.20.6+k0s.0
 # ansible_user: k0s
 # artifacts_dir: "{{ inventory_dir }}/artifacts"
@@ -9,3 +9,9 @@
 # k0s_data_dir: /var/lib/k0s
 # k0s_libexec_dir: /usr/libexec/k0s/
 # k0s_use_custom_config: false
+
+### Docs: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
+# k8s_enable_oidc_auth: false
+# k8s_oidc_issuer_url: https://accounts.google.com
+# k8s_oidc_username_claim: email
+# k8s_oidc_client_id: <secret>

--- a/inventory/vagrant/group_vars/all.yml
+++ b/inventory/vagrant/group_vars/all.yml
@@ -8,3 +8,9 @@
 # k0s_data_dir: /var/lib/k0s
 # k0s_libexec_dir: /usr/libexec/k0s/
 k0s_use_custom_config: true
+
+### https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
+# k8s_enable_oidc_auth: false
+# k8s_oidc_issuer_url: https://accounts.google.com
+# k8s_oidc_username_claim: email
+# k8s_oidc_client_id: <secret>

--- a/rbac_oidc_example.yml
+++ b/rbac_oidc_example.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: oidc-admin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oidc-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oidc-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: user@example.com

--- a/roles/k0s/controller/tasks/main.yml
+++ b/roles/k0s/controller/tasks/main.yml
@@ -10,7 +10,11 @@
 
 - name: Create k0s controller service with install command
   register: install_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token
+  command: >
+    k0s install controller
+      --config {{ k0s_config_dir }}/k0s.yaml
+      --token-file {{ k0s_config_dir }}/controller-token
+      --kubelet-extra-args="--node-ip={{ ansible_host }} --address=0.0.0.0"
   changed_when: install_controller_cmd | length > 0
 
 - name: "Enable and check k0s service"

--- a/roles/k0s/initial_controller/tasks/main.yml
+++ b/roles/k0s/initial_controller/tasks/main.yml
@@ -2,7 +2,10 @@
 
 - name: Create k0s initial controller service with install command
   register: install_initial_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml
+  command: >
+    k0s install controller
+      --config {{ k0s_config_dir }}/k0s.yaml
+      --kubelet-extra-args="--node-ip={{ ansible_host }} --address=0.0.0.0"
   changed_when: install_initial_controller_cmd | length > 0
 
 - name: Enable and check k0s service

--- a/roles/k0s/worker/tasks/main.yml
+++ b/roles/k0s/worker/tasks/main.yml
@@ -10,7 +10,11 @@
 
 - name: Create k0s worker service with install command
   register: install_worker_cmd
-  command: k0s install worker --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/worker-token
+  command: >
+    k0s install worker
+      --config {{ k0s_config_dir }}/k0s.yaml
+      --token-file {{ k0s_config_dir }}/worker-token
+      --kubelet-extra-args="--node-ip={{ ansible_host }} --address=0.0.0.0"
   changed_when: install_worker_cmd | length > 0
 
 - name: Enable and check k0s service

--- a/roles/prereq/templates/k0s.yaml.j2
+++ b/roles/prereq/templates/k0s.yaml.j2
@@ -9,6 +9,12 @@ spec:
     k0sApiPort: 9443
     sans:
     - {{ ansible_host }}
+{% if k8s_enable_oidc_auth %}
+    extraArgs:
+      oidc-issuer-url: {{ k8s_oidc_issuer_url }}
+      oidc-username-claim: {{ k8s_oidc_username_claim }}
+      oidc-client-id: {{ k8s_oidc_client_id }}
+{% endif %}
   storage:
     type: etcd
     etcd:

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -29,7 +29,7 @@
     - "{{ k0s_libexec_dir }}"
     - /var/lib/kubelet
     - "{{ systemd_dest }}/k0scontroller.service"
-
+    - "{{ systemd_dest }}/k0sworker.service"
 - name: daemon_reload
   systemd:
     daemon_reload: yes


### PR DESCRIPTION
I had a few more issues with VMs with more than one network interfaces , added `--kubelet-extra-args=` for that
i also needed a central user store for k8s , so added feature to enable openid connect , if you think this is not the place for it , i could maybe separate the two commits , or you can cherry-pick the first one

refferences for oidc
https://github.com/k0sproject/k0s/issues/864
https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
https://github.com/gini/dexter
https://github.com/micahhausler/k8s-oidc-helper
