### PR TITLE
Feature: Allow extra args to be passes when installing k0s

### DIFF
--- a/roles/k0s/controller/tasks/main.yml
+++ b/roles/k0s/controller/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create k0s controller service with install command
   register: install_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token {{extra_args}}
+  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token {{ extra_args | default(omit) }}
   changed_when: install_controller_cmd | length > 0
 
 - name: "Enable and check k0s service"

--- a/roles/k0s/controller/tasks/main.yml
+++ b/roles/k0s/controller/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create k0s controller service with install command
   register: install_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token
+  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token {{extra_args}}
   changed_when: install_controller_cmd | length > 0
 
 - name: "Enable and check k0s service"

--- a/roles/k0s/initial_controller/tasks/main.yml
+++ b/roles/k0s/initial_controller/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Create k0s initial controller service with install command
   register: install_initial_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml {{extra_args}}
+  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml {{ extra_args | default(omit) }}
   changed_when: install_initial_controller_cmd | length > 0
 
 - name: Enable and check k0s service

--- a/roles/k0s/initial_controller/tasks/main.yml
+++ b/roles/k0s/initial_controller/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Create k0s initial controller service with install command
   register: install_initial_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml
+  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml {{extra_args}}
   changed_when: install_initial_controller_cmd | length > 0
 
 - name: Enable and check k0s service

--- a/roles/k0s/worker/tasks/main.yml
+++ b/roles/k0s/worker/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create k0s worker service with install command
   register: install_worker_cmd
-  command: k0s install worker --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/worker-token
+  command: k0s install worker --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/worker-token {{extra_args}}
   changed_when: install_worker_cmd | length > 0
 
 - name: Enable and check k0s service

--- a/roles/k0s/worker/tasks/main.yml
+++ b/roles/k0s/worker/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create k0s worker service with install command
   register: install_worker_cmd
-  command: k0s install worker --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/worker-token {{extra_args}}
+  command: k0s install worker --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/worker-token {{ extra_args | default(omit) }}
   changed_when: install_worker_cmd | length > 0
 
 - name: Enable and check k0s service


### PR DESCRIPTION
One example would be to pass: `extra_args="--enable-worker"` to allow controller nodes to be worker as well. 