### PR TITLE
Implement virt-lightning for VM deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ $ multipass delete $(multipass list --format csv | grep 'k0s' | cut -d',' -f1)
 $ multipass purge
 ```
 
+## Example with virt-lightning
+
+Virt-lightning (aliased as vl) is tool for fast deploy of virtual machines using Libvirt as backend. Script provided to
+deploy number of VM and generate Ansible inventory. If some machines are running, they are not changed at the script 
+run. 5 VMs are created by default, pass number as argument if needed.
+
+```ShellSession
+$ tools/vl_create_instances_inventory.py
+```
+
+This command will create VMs and generate inventory file in `tools` directory. 
+
+### How to cleanup the cluster
+
+If you have only k0s VMs, just cleanup everything:
+```ShellSession
+$ vl down
+```
+
 ## Test with Vagrant
 
 It's assumed that vagrant is installed, if not, download and install it from their [website](https://www.vagrantup.com/downloads)

--- a/tools/vl_create_instances_inventory.py
+++ b/tools/vl_create_instances_inventory.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+import argparse
+import getpass
+import yaml
+
+from pathlib import Path
+from yaml import SafeDumper
+
+try:
+    import virt_lightning
+except ImportError:
+    print(
+        """
+        Can't import virt-lightning. Install it as described at 
+        
+        https://github.com/virt-lightning/virt-lightning
+        
+        or use scripts for Multipass
+        """
+    )
+
+import virt_lightning.api as vla
+from virt_lightning.configuration import Configuration
+
+
+def numbers_of_vm_val(n):
+    result = int(n)
+    if result < 1:
+        raise ValueError
+    return result
+
+
+DISTRO = "ubuntu-18.04"
+VM_CONFIG = {"distro": DISTRO, "memory": 2048, "vcpus": 2}
+USER = getpass.getuser()
+INVENTORY_TEMPLATE = {
+    "all": {
+        "hosts": {},
+        "vars": {"ansible_user": USER},
+        "children": {
+            "initial_controller": {"hosts": {}},
+            "controller": {"hosts": {}},
+            "worker": {"hosts": {}},
+        },
+    }
+}
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Tool to prepare VMs and Ansible inventory"
+    )
+    parser.add_argument(
+        "number_of_vms",
+        type=numbers_of_vm_val,
+        default="5",
+        nargs="?",
+        help="Number of VMs to deploy",
+    )
+
+    args = parser.parse_args()
+
+    configuration = Configuration()
+    configuration.username = USER
+
+    if DISTRO not in vla.distro_list(configuration=configuration):
+        print(f"Distro {DISTRO} not found, fetching...")
+        vla.fetch(configuration=configuration, distro=DISTRO)
+
+    if args.number_of_vms < 4:
+        vm_name_postfix = ["initial_controller"] + ["worker"] * (
+            args.number_of_vms - 1
+        )
+    else:
+        vm_name_postfix = (
+            ["initial_controller"]
+            + ["controller"] * 2
+            + ["worker"] * (args.number_of_vms - 3)
+        )
+    vm_names = [
+        f"k0s-{idx}-{postfix}" for idx, postfix in enumerate(vm_name_postfix)
+    ]
+
+    # Check if we have some VMs running. Just to form message to user, VL skips
+    # creating of VM if it exists
+    running_vms = [x["name"] for x in vla.status(configuration=configuration)]
+    for vm_name in vm_names:
+        if vm_name in running_vms:
+            print(f"{vm_name} is running")
+            continue
+        print(f"Spinning up {vm_name}")
+        vla.start(configuration=configuration, name=vm_name, **VM_CONFIG)
+
+    # VL outputs inventory as text, so some parsing is needed
+    inventory = {
+        x.split(" ")[0]: x.split(" ")[1].split("=")[1]
+        for x in vla.ansible_inventory(configuration=configuration).split("\n")
+        if x != "" and x.split(" ")[0] in vm_names
+    }
+
+    INVENTORY_TEMPLATE["all"]["hosts"] = {
+        k: {"ansible_host": v} for k, v in inventory.items()
+    }
+    INVENTORY_TEMPLATE["all"]["children"]["initial_controller"]["hosts"] = {
+        x: None for x in inventory if "initial_controller" in x
+    }
+    INVENTORY_TEMPLATE["all"]["children"]["controller"]["hosts"] = {
+        x: None for x in inventory if "-controller" in x
+    }
+    INVENTORY_TEMPLATE["all"]["children"]["worker"]["hosts"] = {
+        x: None for x in inventory if "worker" in x
+    }
+
+    # Dump blanks instead of 'null' by using SafeDumper
+    # https://stackoverflow.com/a/37445121
+    SafeDumper.add_representer(
+        type(None),
+        lambda dumper, value: dumper.represent_scalar(
+            "tag:yaml.org,2002:null", ""
+        ),
+    )
+
+    # Write inventory as yaml
+    yaml_path = Path(__file__).with_name("inventory.yml")
+    with open(yaml_path, "w") as f:
+        f.write(
+            yaml.safe_dump(
+                INVENTORY_TEMPLATE,
+                default_flow_style=False,
+                explicit_start=True,
+            )
+        )
+
+    print(f"Created Ansible Inventory at: {yaml_path}")


### PR DESCRIPTION
Virt-lightning is approximate equivalent of Multipass. It uses only
Libvirt as backend, but much faster and more convenient because it uses
cloud images for guests and do some preconfiguration jobs to prepare
guests for Ansible tasks running