### PR TITLE
remove --config switch + support different extra_args

### DIFF
--- a/inventory/sample/inventory.yml
+++ b/inventory/sample/inventory.yml
@@ -8,6 +8,8 @@ all:
       hosts:
         k0s-2:
         k0s-3:
+      vars:
+        k0s_controller_extra_vars: "--enable-worker"  # this enables workload scheduling also on controllers
     worker:
       hosts:
         k0s-4:

--- a/roles/k0s/controller/tasks/main.yml
+++ b/roles/k0s/controller/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create k0s controller service with install command
   register: install_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token {{ extra_args | default(omit) }}
+  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token {{ k0s_controller_extra_args | default(omit) }}
   changed_when: install_controller_cmd | length > 0
 
 - name: Setup custom environment variables for systemd unit

--- a/roles/k0s/initial_controller/tasks/main.yml
+++ b/roles/k0s/initial_controller/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Create k0s initial controller service with install command
   register: install_initial_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml {{ extra_args | default(omit) }}
+  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml {{ k0s_controller_extra_args | default(omit) }}
   changed_when: install_initial_controller_cmd | length > 0
 
 - name: Setup custom environment variables for systemd unit
@@ -25,7 +25,7 @@
 
 - name: Create worker join token
   register: worker_join_token
-  command: k0s token create --role worker  --config {{ k0s_config_dir }}/k0s.yaml
+  command: k0s token create --role worker
   changed_when: worker_join_token | length > 0
 
 - name: Store worker join token

--- a/roles/k0s/worker/tasks/main.yml
+++ b/roles/k0s/worker/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create k0s worker service with install command
   register: install_worker_cmd
-  command: k0s install worker --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/worker-token {{ extra_args | default(omit) }}
+  command: k0s install worker --token-file {{ k0s_config_dir }}/worker-token {{ k0s_worker_extra_args | default(omit) }}
   changed_when: install_worker_cmd | length > 0
 
 - name: Enable and check k0s service


### PR DESCRIPTION
Hi,

this PR is related to #11 and removes the `--config` CLI switch where it was giving errors.

Also enables different extra_args for controller and workers: before, it wasn't possible to have _schedulable_ controllers as passing `extra_args=--enable-worker` caused failure in the worker setup (it's an option valid only for `k0s install controller`).

Now we can specify `k0s_controller_extra_args` and `k0s_worker_extra_args`.
