### PR TITLE
Upgrade playbook to work with v1.27.5+k0s.0

### DIFF
--- a/reset.yml
+++ b/reset.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: all
+- hosts: initial_controller:controller:worker
   gather_facts: yes
   become: yes
   roles:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-k0s_version: v1.22.4+k0s.1
+k0s_version: v1.27.5+k0s.0
 k0s_binary_dest: /usr/local/bin/k0s

--- a/roles/k0s/initial_controller/tasks/main.yml
+++ b/roles/k0s/initial_controller/tasks/main.yml
@@ -2,7 +2,9 @@
 
 - name: Create k0s initial controller service with install command
   register: install_initial_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml {{ extra_args | default(omit) }}
+  command: k0s install controller {{ extra_args | default(omit) }}
+  args:
+    creates: /etc/systemd/system/k0scontroller.service
   changed_when: install_initial_controller_cmd | length > 0
 
 - name: Setup custom environment variables for systemd unit
@@ -25,7 +27,7 @@
 
 - name: Create worker join token
   register: worker_join_token
-  command: k0s token create --role worker  --config {{ k0s_config_dir }}/k0s.yaml
+  command: k0s token create --role worker
   changed_when: worker_join_token | length > 0
 
 - name: Store worker join token
@@ -44,7 +46,7 @@
 
 - name: Create controller join token
   register: controller_join_token
-  command: k0s token create --role controller --config {{ k0s_config_dir }}/k0s.yaml
+  command: k0s token create --role controller
   changed_when: controller_join_token | length > 0
 
 - name: Store controller join token

--- a/roles/k0s/worker/tasks/main.yml
+++ b/roles/k0s/worker/tasks/main.yml
@@ -10,7 +10,9 @@
 
 - name: Create k0s worker service with install command
   register: install_worker_cmd
-  command: k0s install worker --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/worker-token {{ extra_args | default(omit) }}
+  command: k0s install worker --token-file {{ k0s_config_dir }}/worker-token {{ extra_args | default(omit) }}
+  args:
+    creates: /etc/systemd/system/k0sworker.service
   changed_when: install_worker_cmd | length > 0
 
 - name: Enable and check k0s service

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: all
+- hosts: initial_controller:controller:worker
   name: Download k0s on all nodes
   become: yes
   roles:


### PR DESCRIPTION
Hi there!
Most of this is updating the version being installed, and removing the arg which is no longer valid in the latest version, `  --config {{ k0s_config_dir }}/k0s.yaml`.

I also changed `hosts: all` because I was getting some weird behavior and errors with ansible trying to gather facts on my localhost, which really isn't necessary for this playbook. Instead, we can list all the relevant groups that should be included.

Lastly, I added this block to the `k0s install controller/worker` commands to make the playbook more idempotent.
```
  args:
    creates: /etc/systemd/system/k0scontroller.service
```
Without this, the playbook was failing for me on re-runs. If anything errors out on the first run after this command but before successful cluster setup, we want this to be safe to re-run.