### PR TITLE
Add support for `uv run` for multipass script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Generate your Ansible inventory:
 
 ```ShellSession
 $ cp -rfp inventory/sample inventory/multipass
-$ ./tools/multipass_generate_inventory.py
+$ uv run ./tools/multipass_generate_inventory.py
 Designate first instance as control plane
 Created Ansible Inventory at: /Users/dev/k0s-ansible/tools/inventory.yml
 $ cp tools/inventory.yml inventory/multipass/inventory.yml

--- a/tools/multipass_generate_inventory.py
+++ b/tools/multipass_generate_inventory.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "PyYAML",
+# ]
+# ///
+
 import subprocess
 import json
 import yaml


### PR DESCRIPTION
```ShellSession
$  uv run ./tools/multipass_generate_inventory.py
Installed 1 package in 3ms
Designated first three instances as control plane nodes.
Created Ansible Inventory at: k0s-ansible/tools/inventory.yml
```
