### PR TITLE
Updates to include k0s v1.33

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-k0s_version: v1.27.5+k0s.0
+k0s_version: v1.33.1+k0s.1
 k0s_binary_dest: /usr/local/bin/k0s

--- a/roles/k0s/controller/tasks/main.yml
+++ b/roles/k0s/controller/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create k0s controller service with install command
   register: install_controller_cmd
-  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token {{ extra_args | default(omit) }}
+  command: k0s install controller --config {{ k0s_config_dir }}/k0s.yaml --token-file {{ k0s_config_dir }}/controller-token {{ extra_args | default(None) }}
   changed_when: install_controller_cmd | length > 0
 
 - name: Setup custom environment variables for systemd unit

--- a/roles/k0s/initial_controller/tasks/main.yml
+++ b/roles/k0s/initial_controller/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Create k0s initial controller service with install command
   register: install_initial_controller_cmd
-  command: k0s install controller {% if k0s_single_node %} --enable-worker --single {% endif %} {{ extra_args | default(omit) }}
+  command: k0s install controller {% if k0s_single_node %} --enable-worker --single {% endif %} {{ extra_args | default(None) }}
   args:
     creates: /etc/systemd/system/k0scontroller.service
   changed_when: install_initial_controller_cmd | length > 0

--- a/roles/k0s/worker/tasks/main.yml
+++ b/roles/k0s/worker/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create k0s worker service with install command
   register: install_worker_cmd
-  command: k0s install worker --token-file {{ k0s_config_dir }}/worker-token {{ extra_args | default(omit) }}
+  command: k0s install worker --token-file {{ k0s_config_dir }}/worker-token {{ extra_args | default(None) }}
   args:
     creates: /etc/systemd/system/k0sworker.service
   changed_when: install_worker_cmd | length > 0

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -25,10 +25,10 @@
 - name: Generate default k0s config file
   become: true
   block:
-    - name: Create default k0s config
+    - name: "Create default k0s config {{ k0s_config_dir }}/k0s.yaml"
       register: default_k0s_config
-      command: k0s default-config > {{ k0s_config_dir }}/k0s.yaml
-    - name: Store default k0f config
+      command: "k0s config create"
+    - name: Store default k0s config
       copy:
         dest: "{{ k0s_config_dir }}/k0s.yaml"
         content: "{{ default_k0s_config.stdout }}"


### PR DESCRIPTION
Updated k0s to v1.33
Was throwing an `__omit_place_holder__` error . Changed ansible defaults from omit to None.
Updated deprecated create config command and clarified the variable creation and subsequent file creation from stdout content.